### PR TITLE
Fixed "keyname is empty by default"

### DIFF
--- a/core/components/rememberthis/model/rememberthis/rememberthis.class.php
+++ b/core/components/rememberthis/model/rememberthis/rememberthis.class.php
@@ -76,7 +76,7 @@ class RememberThis
             'itemTitleTpl' => $this->getOption('itemTitleTpl', $options, 'tplRememberThisItemTitle'),
             'packagename' => $this->getOption('packagename', null, ''),
             'classname' => $this->getOption('classname', null, ''),
-            'keyname' => $this->getOption('keyname', null, 'id'),
+            'keyname' => $this->getOption('keyname', null, 'id', true),
             'joins' => $this->modx->fromJson($this->getOption('joins', null, '')),
             'jQueryPath' => $this->getOption('jQueryPath', null, ''),
             'includeScripts' => intval($this->getOption('includeScripts', null, 1)),


### PR DESCRIPTION
https://rtfm.modx.com/xpdo/2.x/class-reference/xpdo/xpdo.getoption

$skipEmpty: when set to true, the $default will also be returned if the $key's value is an empty string. **Added in xPDO 2.2.1 / MODX 2.2.0-rc2**.
